### PR TITLE
Allowing base 4.7

### DIFF
--- a/picologic.cabal
+++ b/picologic.cabal
@@ -32,7 +32,7 @@ library
   hs-source-dirs:      src
   other-extensions:    DeriveDataTypeable, BangPatterns
   build-depends:       
-    base        >= 4.6 && <4.7,
+    base        >= 4.6 && <4.8,
     picosat     >= 0.1 && <0.2,
     containers  >= 0.5 && <0.6,
     mtl         >= 2.1 && <2.2,
@@ -47,7 +47,7 @@ executable picologic
     other-modules: Picologic.Repl
     other-extensions:    DeriveDataTypeable, BangPatterns
     build-depends:       
-      base        >= 4.6 && <4.7,
+      base        >= 4.6 && <4.8,
       picosat     >= 0.1 && <0.2,
       containers  >= 0.5 && <0.6,
       mtl         >= 2.1 && <2.2,


### PR DESCRIPTION
Once you verify that this change is okay, please make sure to bump the version number on `picologic` and `picosat` and upload new versions to Hackage!

Thanks!
