### PR TITLE
Added missing Picologic.Pretty to cabal

### DIFF
--- a/picologic.cabal
+++ b/picologic.cabal
@@ -28,7 +28,8 @@ library
     Picologic,
     Picologic.Solver,
     Picologic.AST,
-    Picologic.Parser
+    Picologic.Parser,
+    Picologic.Pretty
   hs-source-dirs:      src
   other-extensions:    DeriveDataTypeable, BangPatterns
   build-depends:       


### PR DESCRIPTION
It seems that picologic.cabal is missing the Picologic.Pretty module and the package fails to build for me. Here is a pr to add that.