### PR TITLE
Adding Picologic.Lexer to "other-modules" in .cabal file.

### DIFF
--- a/picologic.cabal
+++ b/picologic.cabal
@@ -30,6 +30,8 @@ library
     Picologic.AST,
     Picologic.Parser,
     Picologic.Pretty
+  other-modules:
+    Picologic.Lexer
   hs-source-dirs:      src
   other-extensions:    DeriveDataTypeable, BangPatterns
   build-depends:       


### PR DESCRIPTION
According to the cabal documentation, modules that are not exposed to
the end-user should go in the "other-modules" field in the .cabal file.

https://www.haskell.org/cabal/users-guide/developing-packages.html#modules-included-in-the-package