### PR TITLE
Added logic constants true and false, refactor expression simplifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ p, q, r :: Expr
 p = readExpr "~(A | B)"
 q = readExpr "(A | ~B | C) & (B | D | E) & (D | F)"
 r = readExpr "(φ <-> ψ)"
+s = readExpr "(0 | A) -> (A & 1)"
 
 ps = ppExprU p
 -- ¬(A ∨ B)
@@ -47,6 +48,10 @@ qs = ppExprU q
 -- ((((A ∨ ¬B) ∨ C) ∧ ((B ∨ D) ∨ E)) ∧ (D ∨ F))
 rs = ppExprU (cnf r)
 -- ((φ ∧ (φ ∨ ¬ψ)) ∧ ((ψ ∨ ¬φ) ∧ ψ))
+ss = ppExprU s
+-- ((⊥ ∨ A) → (A ∧ ⊤))
+ss1 = ppExprU (cnf s)
+-- ⊤
 
 main :: IO ()
 main = solveProp p >>= putStrLn . ppSolutions
@@ -55,7 +60,7 @@ main = solveProp p >>= putStrLn . ppSolutions
 -- A ¬B
 ```
 
-The expression AST consists just of the logical connectives. 
+The expression AST consists just of the logical connectives or constants. 
 
 ```haskell
 newtype Ident = Ident String

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ data Expr
   | Disj      Expr Expr  -- ^ Logical disjunction
   | Iff       Expr Expr  -- ^ Logical biconditional
   | Implies   Expr Expr  -- ^ Material implication
+  | Top                  -- ^ Constant true
+  | Bottom               -- ^ Constant false
   deriving (Eq, Ord, Show, Data, Typeable)
 ```
 

--- a/picologic.cabal
+++ b/picologic.cabal
@@ -1,5 +1,5 @@
 name:                picologic
-version:             0.1.2
+version:             0.2.0
 synopsis:            Utilities for symbolic predicate logic expressions
 homepage:            https://github.com/sdiehl/picologic
 license:             MIT

--- a/src/Picologic/AST.hs
+++ b/src/Picologic/AST.hs
@@ -13,6 +13,8 @@ module Picologic.AST (
   cnf,
   nnf,
   simp,
+  isConst,
+  propConst
 ) where
 
 import Data.List
@@ -34,6 +36,8 @@ data Expr
   | Disj      Expr Expr  -- ^ Logical disjunction
   | Iff       Expr Expr  -- ^ Logical biconditional
   | Implies   Expr Expr  -- ^ Material implication
+  | Top                  -- ^ Constant true
+  | Bottom               -- ^ Constant false
   deriving (Eq, Ord, Data, Typeable)
 
 -- | Evaluate expression.
@@ -41,9 +45,11 @@ eval :: Ctx -> Expr -> Bool
 eval vs (Var v)           = fromMaybe False (M.lookup v vs)
 eval vs (Neg expr)        = not $ eval vs expr
 eval vs (Conj e1 e2)      = eval vs e1 && eval vs e2
-eval vs (Disj   e1 e2)    = eval vs e1 || eval vs e2
-eval vs (Implies   e1 e2) = not (eval vs e1) || eval vs e2
+eval vs (Disj e1 e2)      = eval vs e1 || eval vs e2
+eval vs (Implies e1 e2)   = not (eval vs e1) || eval vs e2
 eval vs (Iff e1 e2)       = eval vs e1 == eval vs e2
+eval vs (Top)             = True
+eval vs (Bottom)          = False
 
 -- | Variables in expression
 variables :: Expr -> [Ident]
@@ -55,31 +61,28 @@ variables expr = map head . group . sort $ go expr []
     go (Disj e1 e2)    !vs = go e1 vs ++ go e2 vs
     go (Iff e1 e2)     !vs = go e1 vs ++ go e2 vs
     go (Implies e1 e2) !vs = go e1 vs ++ go e2 vs
+    go (Top)           !vs = vs
+    go (Bottom)        !vs = vs
 
 -- | Negation normal form.
 -- (May result in exponential growth)
 nnf :: Expr -> Expr
-nnf ex = case ex of
-  e@(Var _)             -> e
-  e@(Neg (Var _))       -> e
-  Neg (Neg e)           -> nnf e
+nnf = transformDown nnf1 . propConst
 
-  Conj e1 e2            -> nnf e1 `Conj` nnf e2
-  Neg (Conj e1 e2)      -> nnf $ Neg e1 `Disj` Neg e2
-
-  Disj e1 e2            -> nnf e1 `Disj` nnf e2
-  Neg (Disj e1 e2)      -> nnf $ Neg e1 `Conj` Neg e2
-
-  Implies e1 e2         -> nnf $ Neg e1 `Disj` e2
-  Neg (Implies e1 e2)   -> nnf $ e1 `Conj` Neg e2
-
-  Iff e1 e2             -> let a = e1 `Disj` Neg e2
-                               b = Neg e1 `Disj` e2
-                               in nnf $ a `Conj` b
-
-  Neg (Iff e1 e2)       -> let a = e1 `Disj` e2
-                               b = Neg e1 `Disj` Neg e2
-                               in nnf $ a `Conj` b
+nnf1 :: Expr -> Expr
+nnf1 ex = case ex of
+  Neg (Neg e) -> nnf1 e
+  Neg (Conj e1 e2) -> Neg e1 `Disj` Neg e2
+  Neg (Disj e1 e2) -> Neg e1 `Conj` Neg e2
+  Implies e1 e2 -> Neg e1 `Disj` e2
+  Neg (Implies e1 e2) -> e1 `Conj` Neg e2
+  Iff e1 e2 -> let a = e1 `Disj` Neg e2
+                   b = Neg e1 `Disj` e2
+               in a `Conj` b
+  Neg (Iff e1 e2) -> let a = e1 `Disj` e2
+                         b = Neg e1 `Disj` Neg e2
+                     in a `Conj` b
+  e -> e
 
 -- | Conjunctive normal form.
 -- (May result in exponential growth)
@@ -98,10 +101,69 @@ cnf = simp . cnf' . nnf
 
 -- | Remove tautologies.
 simp :: Expr -> Expr
-simp ex = case ex of
-  -- Disj e1 (Neg e2) | e1 == e2 -> True
-  -- Disj (Neg e1) e2 | e1 == e2 -> True
-  Disj e1 e2 -> Disj (simp e1) (simp e2)
+simp = transformUp (propConst1 . simp1)
+
+simp1 :: Expr -> Expr
+simp1 ex = case ex of
+  Disj e1 (Neg e2) | e1 == e2 -> Top
+  Disj (Neg e1) e2 | e1 == e2 -> Top
   Conj e1 e2       | e1 == e2 -> e1
-                   | otherwise -> Conj (simp e1) (simp e2)
+  e -> e
+
+-- | Test if expression is constant.
+isConst :: Expr -> Bool
+isConst Top = True
+isConst Bottom = True
+isConst e = False
+
+-- | Transform expression up from the bottom.
+transformUp :: (Expr -> Expr) -> Expr -> Expr
+-- TODO: This could probably be done with Data.Data, but it's outside my capabilities for now. 
+transformUp f ex = case ex of
+  Neg e -> f $ Neg (transformUp f e)
+  Conj e1 e2 -> f $ Conj (transformUp f e1) (transformUp f e2)
+  Disj e1 e2 -> f $ Disj (transformUp f e1) (transformUp f e2)
+  Iff e1 e2 -> f $ Iff (transformUp f e1) (transformUp f e2)
+  Implies e1 e2 -> f $ Implies (transformUp f e1) (transformUp f e2)
+  e -> f e
+
+-- | Transform expression down from the top.
+transformDown :: (Expr -> Expr) -> Expr -> Expr
+-- TODO: This could probably be done with Data.Data, but it's outside my capabilities for now. 
+transformDown f ex = case f ex of
+  Neg e -> Neg (transformDown f e)
+  Conj e1 e2 -> Conj (transformDown f e1) (transformDown f e2)
+  Disj e1 e2 -> Disj (transformDown f e1) (transformDown f e2)
+  Iff e1 e2 -> Iff (transformDown f e1) (transformDown f e2)
+  Implies e1 e2 -> Implies (transformDown f e1) (transformDown f e2)
+  e -> e
+
+-- | Propagate constants (to simplify expression).
+propConst :: Expr -> Expr
+propConst = transformUp propConst1
+
+propConst1 :: Expr -> Expr
+propConst1 ex = case ex of
+  Neg (Neg e) -> e
+  Neg Top -> Bottom
+  Neg Bottom -> Top
+  Conj Top e2 -> e2
+  Conj Bottom e2 -> Bottom
+  Conj e1 Top -> e1
+  Conj e1 Bottom -> Bottom
+  Disj Top e2 -> Top
+  Disj Bottom e2 -> e2
+  Disj e1 Top -> Top
+  Disj e1 Bottom -> e1
+  Iff Top Bottom -> Bottom
+  Iff Bottom Top -> Bottom
+  Iff Bottom Bottom -> Top
+  Iff Top e2 -> e2
+  Iff Bottom e2 -> Neg e2
+  Iff e1 Top -> e1
+  Iff e1 Bottom -> Neg e1
+  Implies Top e2 -> e2
+  Implies Bottom e2 -> Top
+  Implies e1 Top -> Top
+  Implies e1 Bottom -> Neg e1
   e -> e

--- a/src/Picologic/Lexer.hs
+++ b/src/Picologic/Lexer.hs
@@ -34,7 +34,7 @@ reservedOps = [
   ]
 
 reservedNames :: [String]
-reservedNames = []
+reservedNames = ["1","0"]
 
 lexerStyle :: Language
 lexerStyle = haskellStyle

--- a/src/Picologic/Parser.hs
+++ b/src/Picologic/Parser.hs
@@ -32,11 +32,16 @@ var = do
   x <- identifier
   return $ Var (Ident x)
 
+constant :: Parser Expr
+constant = (reserved "1" >> return Top)
+       <|> (reserved "0" >> return Bottom)
+
 cexpr :: Parser Expr
 cexpr =  Ex.buildExpressionParser operators cfactor
 
 cfactor :: Parser Expr
-cfactor =  var
+cfactor =  constant
+       <|> var
        <|> parens cexpr
 
 parseExpr :: String -> Either ParseError Expr

--- a/src/Picologic/Solver.hs
+++ b/src/Picologic/Solver.hs
@@ -2,7 +2,8 @@ module Picologic.Solver (
   solveProp,
   solveCNF,
   solveOneCNF,
-  clausesExpr
+  clausesExpr,
+  addVarsToSolutions
 ) where
 
 import Picologic.AST
@@ -10,7 +11,9 @@ import Picologic.Pretty
 import Picosat
 
 import Data.List
+import Data.Maybe(mapMaybe)
 import qualified Data.Map as M
+import qualified Data.Set as S
 import Control.Monad.Writer
 
 -- | Yield the solutions for an expression using the PicoSAT solver.
@@ -20,9 +23,14 @@ solveProp p = solveCNF $ cnf p
 -- | Yield the solutions for an expression using the PicoSAT
 -- solver. The Expression must be in CNF form already.
 solveCNF :: Expr -> IO Solutions
-solveCNF p = do
-  solutions <- solveAll ds
-  return $ Solutions $ fmap (backSubst vs') solutions
+solveCNF p = if isConst p
+             then
+               return $ if eval M.empty p
+                        then Solutions [[]]
+                        else Solutions []
+             else do
+                 solutions <- solveAll ds
+                 return $ Solutions $ mapMaybe (backSubst vs') solutions
   where
     cs = clausesFromCNF p
     ds = cnfToDimacs vs cs
@@ -32,10 +40,15 @@ solveCNF p = do
 
 -- | Yield one single solution for an expression using the PicoSAT
 -- solver. The Expression must be in CNF form already.
-solveOneCNF :: Expr -> IO [Expr]
-solveOneCNF p = do
-  solution <- solve ds
-  return $ backSubst vs' solution
+solveOneCNF :: Expr -> IO (Maybe [Expr])
+solveOneCNF p = if isConst p
+                then
+                  return $ if eval M.empty p
+                           then Just []
+                           else Nothing
+                else do
+                  solution <- solve ds
+                  return $ backSubst vs' solution
   where
     cs = clausesFromCNF p
     ds = cnfToDimacs vs cs
@@ -44,13 +57,12 @@ solveOneCNF p = do
     vars = variables p
 
 clausesFromCNF :: Expr -> [[Expr]]
-clausesFromCNF p =
-  [ [ case lit of
-         v@(Var name) -> v
-         v@(Neg (Var name)) -> v
-         x -> error $ "input not in CNF: \n" ++ show p
-    | lit <- ors [clause] ]
-  | clause <- ands [p]]
+clausesFromCNF p = [ [ case lit of
+                       v@(Var name) -> v
+                       v@(Neg (Var name)) -> v
+                       x -> error $ "input not in CNF: \n" ++ show p
+                     | lit <- ors [clause] ]
+                   | clause <- ands [p]]
 
 ands :: [Expr] -> [Expr]
 ands [] = []
@@ -63,7 +75,7 @@ ors (Disj a b : xs) = ors [a] ++ ors [b] ++ ors xs
 ors (x:xs) = x : ors xs
 
 cnfToDimacs :: M.Map Ident Int -> [[Expr]] -> [[Int]]
-cnfToDimacs vs cs = map (map encode) cs
+cnfToDimacs vs = map (map encode)
   where encode (Var ident)       = vs M.! ident
         encode (Neg (Var ident)) = negate $ vs M.! ident
   
@@ -77,11 +89,16 @@ clausesExpr p = ds
     vars = variables p
     ds = cnfToDimacs vs cs
 
-backSubst :: M.Map Int Ident -> Solution -> [Expr]
-backSubst env (Solution xs) = fmap go xs
+backSubst :: M.Map Int Ident -> Solution -> Maybe [Expr]
+backSubst env (Solution xs) = Just $ fmap go xs
   where
     go x | x >= 0 = Var (env M.! x)
-    go x | x < 0 = Neg (Var (env M.! (abs x)))
-backSubst _ Unsatisfiable = []
-backSubst _ Unknown = []
+    go x | x < 0 = Neg (Var (env M.! abs x))
+backSubst _ Unsatisfiable = Nothing
+backSubst _ Unknown = Nothing
 
+addVarsToSolutions :: [Ident] -> Solutions -> Solutions
+addVarsToSolutions vars (Solutions sols) = Solutions $ concatMap addVarsToSolution sols
+  where
+    addVarsToSolution sol = map (sol ++) $ sequence  [ [Var v, Neg(Var v)] | v <- newVars $ head sols ]
+    newVars sol = vars \\ concatMap variables sol

--- a/src/Picologic/Tseitin.hs
+++ b/src/Picologic/Tseitin.hs
@@ -33,12 +33,12 @@ var = do
   put $ succ n
   return $ Var $ Ident $ "ts*" ++ show n
 
-or xs = foldl1 Disj xs
-and xs = foldl1 Conj xs
+or = foldl1 Disj
+and = foldl1 Conj
 
 tseitinCNF :: Expr -> Expr
 tseitinCNF e =
-  let (var, clauses) = evalTS $ tseitin $ simplify e
+  let (var, clauses) = evalTS $ tseitin $ propConst e
   in and (var : clauses)
 
 neg (Neg x) = x
@@ -156,6 +156,10 @@ tseitin (Neg x) = do
         or [a, c]]
   return c
 
+tseitin Top = return Top
+
+tseitin Bottom = return Bottom
+
 dropTseitinVarsInSolutions (Solutions xs) =
   Solutions $ map dropTseitinVars xs
 
@@ -171,12 +175,3 @@ isTseitinLiteral lit =
 tseitinName ('t':'s':'*':_) = True
 tseitinName _               = False
 
-simplify :: Expr -> Expr
-simplify (Neg (Neg x)) = simplify x
-simplify v@(Var _) = v
-simplify (Neg a) = neg $ simplify a
-simplify (Conj a b) = Conj (simplify a) (simplify b)
-simplify (Disj a b) = Disj (simplify a) (simplify b)
-simplify (Implies a b) = Implies (simplify a) (simplify b)
-simplify (Iff a b) = Iff (simplify a) (simplify b)
-                        

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -42,10 +42,11 @@ instance Arbitrary Expr where
   shrink Bottom = []
 
 
-env = M.fromList [(Ident "a", True),
-                  (Ident "b", True),
-                  (Ident "c", False),
-                  (Ident "d", False)]
+envl = [(Ident "a", True),
+        (Ident "b", True),
+        (Ident "c", False),
+        (Ident "d", False)]
+env = M.fromList envl
 
 test_nnf :: Expr -> Bool
 test_nnf e = eval env e == eval env (nnf e)
@@ -75,6 +76,15 @@ test_tseitin e = unsafePerformIO test
           return $ normalize as1 == normalize bs1
         normalize (Solutions ssv) = sort $ map sort ssv
 
+test_partEval :: Expr -> Bool
+test_partEval e = if eval env e
+                  then elast == Top
+                  else elast == Bottom
+  where
+    envs = map (\(i,v) -> M.singleton i v) envl
+    elast = last $ scanl (flip partEval) e envs
+
+
 qc = verboseCheckWith (stdArgs { maxSuccess = 2000 })
 
 -- how to make an error fail a 'cabal test'?
@@ -88,3 +98,5 @@ main = do
   qc test_cnf
   putStrLn "tseitin"
   qc test_tseitin
+  putStrLn "partEval"
+  qc test_partEval


### PR DESCRIPTION
Hi Stephen,

I am pretty new to Haskell, I wanted to try out a SAT solver for something, and Picologic seemed very convenient, but it was missing logical constants, so I added them. This turned out to be more complicated than I thought, mainly because there is not a good support for constants in Dimacs format, so I had to go through some hoops to fix the test due to missing variables that may be removed during expression transformations. I also tried to refactor the expression simplification a little bit, but I am not completely happy with that part either. 

I want to add some more things to Picologic in the future - namely expression substitution and partial evaluation, maybe improve the Tseitin transform as per your TODO and also perhaps change the format of solutions to a "decision tree" instead of list internally.

Anyway, I like your blog, so any suggestions regarding this are appreciated!

Best,
Jan Samohyl
